### PR TITLE
Remove the copy-pasted `inherits` function in favor of Backbone's extend

### DIFF
--- a/backbone.validations.js
+++ b/backbone.validations.js
@@ -45,7 +45,7 @@ var validators = {
 
   "email" : function(type, attributeName, model, valueToSet) {
     var emailRegex = new RegExp("[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?");
-  
+
     if (_.isString(valueToSet) && !valueToSet.match(emailRegex)) {
       return "email";
     }
@@ -163,7 +163,7 @@ function createMaxValidator(attributeName, maximumValue) {
 
    returns a function that takes in:
      - the value being set for the attribute
-   
+
      and either returns nothing (undefined),
      or the error name (string).
   */
@@ -171,7 +171,7 @@ function createValidator(attributeName, type, description) {
   var validator,
       validatorMethod,
       customValidator;
-  
+
   if (type === "type") {
     type = description;
   }
@@ -216,7 +216,7 @@ function createAttributeValidator(attributeName, attributeDescription) {
         }
       }
     }
-    
+
     if (errors.length) {
       return errors;
     } else {
@@ -255,31 +255,11 @@ function newPerformValidation(attrs, options) {
   return true;
 }
 
-// the following inheritance method is ripped straight from Backbone.
-// it would be nice if backbone made this public
-// so that i could avoid this repetition.
-var ctor = function(){};
-var inherits = function(parent, protoProps, staticProps) {
-  var child;
-  if (protoProps && protoProps.hasOwnProperty('constructor')) {
-    child = protoProps.constructor;
-  } else {
-    child = function(){ return parent.apply(this, arguments); };
-  }
-  ctor.prototype = parent.prototype;
-  child.prototype = new ctor();
-  if (protoProps) { _.extend(child.prototype, protoProps); }
-  if (staticProps) { _.extend(child, staticProps); }
-  child.prototype.constructor = child;
-  child.__super__ = parent.prototype;
-  return child;
-};
-
 // save the old backbone
 var oldModel = Backbone.Model;
 
 // Constructor for our new Validations Model
-Backbone.Validations.Model = inherits(Backbone.Model, {
+Backbone.Validations.Model = Backbone.Model.extend({
   constructor : function() {
     // if they pass an object, construct the new validations
     if (typeof this.validate === "object" && this.validate !== null) {
@@ -289,10 +269,10 @@ Backbone.Validations.Model = inherits(Backbone.Model, {
         this.constructor.prototype._performValidation = newPerformValidation;
       }
     }
-    
+
     oldModel.apply(this, arguments);
   }
-}, Backbone.Model);
+});
 
 // Override Backbone.Model with our new Model
 Backbone.Model = Backbone.Validations.Model;


### PR DESCRIPTION
Backbone's `extend` function uses `inherits` to do its work, so simpler to just use it.
