### PR TITLE
Made email validation case-insensitive

### DIFF
--- a/backbone.validations.js
+++ b/backbone.validations.js
@@ -44,7 +44,7 @@ var validators = {
   },
 
   "email" : function(type, attributeName, model, valueToSet) {
-    var emailRegex = new RegExp("[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?");
+    var emailRegex = new RegExp("[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", "i");
 
     if (_.isString(valueToSet) && !valueToSet.match(emailRegex)) {
       return "email";


### PR DESCRIPTION
The email regex is case-sensitive meaning email addresses with Uppercase characters will fail validation.

This is a one-liner (well, 5 characters) that fixes this
