### PR TITLE
Adding a "validated" event

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -133,8 +133,9 @@ var CustomGlobalUsingValidationDudeModel = Backbone.Model.extend({
 
 ### Integrates with [Backbone-Nested](http://afeld.github.com/backbone-nested/)
 
-Backbone-Nested allows you to specify nested attributes with 1-1 and 1-N relationships. You can specify validation 
-rules using dot notation and empty square brackets.
+Backbone-Nested allows you to specify nested attributes with 1-1 and 1-N relationships. You can define validations 
+for nested attributes using dot notation and empty square brackets. You will need to import backbone-nested separately
+to use this. See the [unit tests](testIntegrationWithBackboneNested.htm) for more examples.
 
 ```javascript
 var ValidatingModel = Backbone.Model.extend({

--- a/README.markdown
+++ b/README.markdown
@@ -135,7 +135,7 @@ var CustomGlobalUsingValidationDudeModel = Backbone.Model.extend({
 
 Backbone-Nested allows you to specify nested attributes with 1-1 and 1-N relationships. You can define validations 
 for nested attributes using dot notation and empty square brackets. You will need to import backbone-nested separately
-to use this. See the [unit tests](testIntegrationWithBackboneNested.htm) for more examples.
+to use this. See testIntegrationWithBackboneNested.htm for more examples.
 
 ```javascript
 var ValidatingModel = Backbone.Model.extend({

--- a/README.markdown
+++ b/README.markdown
@@ -84,6 +84,18 @@ vm.bind('error:name', function(model, errs) {
 });
 ```
 
+### Bind with validated events
+
+The Backbone change event will not fire in cases where the same value is set on the attribute, but if you want to detect validation in these cases, use the "validated" event.
+
+```javascript
+var vm = new ValidatingModel;
+
+vm.bind('validated', function(model, attrs) {
+  // wherein attrs contains the validated attributes
+});
+```
+
 ### Define custom model validators
 
 ```javascript

--- a/README.markdown
+++ b/README.markdown
@@ -131,6 +131,26 @@ var CustomGlobalUsingValidationDudeModel = Backbone.Model.extend({
 });
 ```
 
+### Integrates with [Backbone-Nested](http://afeld.github.com/backbone-nested/)
+
+Backbone-Nested allows you to specify nested attributes with 1-1 and 1-N relationships. You can specify validation 
+rules using dot notation and empty square brackets.
+
+```javascript
+var ValidatingModel = Backbone.Model.extend({
+  validate : {
+    "person.name" : {
+      pattern   : /^[a-zA-Z]+$/,
+      minlength : 3,
+      maxlength : 100
+    },
+	"person.addresses[].city" : {
+	  maxlength : 100
+	}
+  }
+});
+```
+
 Give 'er a go!
 
 ### OH AND THERE'S A NOCONFLICT

--- a/backbone.validations.js
+++ b/backbone.validations.js
@@ -186,8 +186,8 @@ function newValidate(attributes) {
 	if (attrNameType !== attrNameTypeEnum.ARRAY) {
 		var errorsForAttribute = "";
 		
-		attrName = attrName.replace(/\[\d+\]/g, "[]");
-		var validateAttribute = this._attributeValidators[attrName];
+		var attrValidatorName = attrName.replace(/\[\d+\]/g, "[]");
+		var validateAttribute = this._attributeValidators[attrValidatorName];
 		if (validateAttribute)  {
 		  errorsForAttribute = validateAttribute(this, valueToSet);
 		}
@@ -200,14 +200,6 @@ function newValidate(attributes) {
   }
 
   return errorHasOccured ? errors : false;
-}
-
-/*
- Inner validation function called recursively by newValidate while traversing
- nested model attribute tree
-*/
-function validateInner(valueToSet, attrName, errorHasOccured, errors) {
-	
 }
 
 function createMinValidator(attributeName, minimumValue) {
@@ -333,11 +325,7 @@ Backbone.Validations.Model = Backbone.Model.extend({
       if (!this.constructor.prototype._attributeValidators) {
         this.constructor.prototype._attributeValidators = createValidators(this.validate);
         this.constructor.prototype.validate = newValidate;
-		
-		// Have to add this to the model prototype to support recursive function call by newValidate
-		this.constructor.prototype._validateInner = validateInner;
-		
-        this.constructor.prototype._validate = newPerformValidation;
+		this.constructor.prototype._validate = newPerformValidation;
       }
     }
 

--- a/backbone.validations.js
+++ b/backbone.validations.js
@@ -208,8 +208,8 @@ function newValidate(attributes, chgs) {
 				}
 			}
 			
-		// if changes have been passed in we can skip the blanket inflation of all arrays and just
-	    // and just validate the changed key and value.
+		// if changes have been passed in we can skip the blanket inflation of all arrays
+	    	// and just validate the changed key and value.
 		} else if (uninflatedChanges[attrName]) {
 
 			  for(var c in chgs){

--- a/backbone.validations.js
+++ b/backbone.validations.js
@@ -125,81 +125,116 @@ Backbone.Validations.addValidator = function(name, validator) {
     }
 
   */
-function newValidate(attributes) {
-  var errorsForAttribute,
-      errorHasOccured,
-      errors = {},
-	  valueToSet;
-  
-  // Copy _attributeValidators into another array, which will grow as nested collections are inflated
-  var attrNames = _.keys(this._attributeValidators);
-  
-  for (var i = 0; i < attrNames.length; i++) {
-	// Handle names for nested attributes	
-	var attrName = attrNames[i];
-	var attrNameFragments = attrName.split(".");
-	
-	for (var j = 0; j < attrNameFragments.length; j++) {
-		var element = attrNameFragments[j];
-		var attrNameTypeEnum = {
-			NORMAL : 0,
-			ARRAY : 1,
-			ARRAY_ITEM : 2
-		}
-		var attrNameType = attrNameTypeEnum.NORMAL;
-		var arrayIndex = -1;
+function newValidate(attributes, chgs) {
+	  var errorsForAttribute,
+	      errorHasOccured,
+	      errors = {},
+		  valueToSet;
+	  
+	  // Copy _attributeValidators into another array, which will grow as nested collections are inflated
+	  var attrNames = _.keys(this._attributeValidators);
+	  
+	  var uninflatedChanges = {};
+	  
+	  for(var a in chgs){
+		  var value = chgs[a];
+		  a = a.replace(/\[\d+\]/g, "[]");
+		  uninflatedChanges[a] = value; 
+	  }
+	  
+	  for (var i = 0; i < attrNames.length; i++) {
+		// Handle names for nested attributes	
+		var attrName = attrNames[i];
 		
-		// Determine attribute name fragment type: (normal, uninflated array [], or inflated array item [n])
-		element = element.replace(/\[(\d*)\]/, function(match, p1) {
-			if (match === "[]") {
-				attrNameType = attrNameTypeEnum.ARRAY;
-			} else {
-				attrNameType = attrNameTypeEnum.ARRAY_ITEM;
-				arrayIndex = p1;
-			}
-			return "";
-		});
-		
-		// Advance the placeholder in the JSON tree to reflect the current attribute name fragment
-		if (j == 0) {
-			if (attrNameType === attrNameTypeEnum.ARRAY_ITEM) {
-				valueToSet = attributes[element][arrayIndex];
-			} else valueToSet = attributes[element];
-		} else {
-			if (attrNameType === attrNameTypeEnum.ARRAY_ITEM) {
-				valueToSet = valueToSet[element][arrayIndex];
-			} else valueToSet = valueToSet[element];
-		}
+		// if no changes have been passed, do nothing different than before.
+		if(chgs === undefined){
+			var attrNameFragments = attrName.split(".");
 			
-		// If this is an uninflated array, inflate it by appending array item entries to the end of attrNames
-		if (attrNameType === attrNameTypeEnum.ARRAY) {
-		  for (var k = 0; k < valueToSet.length; k++) {
-			// Copy attrName into var, find the position of the first [] in the attrName, replace with [j], and push to attrNames
-			var nameToPush = attrName.replace("[]", "[" + k + "]");
-			attrNames.push(nameToPush);
-		  }
-		  break;
-		} 
-	}
-	
-	// Skip the attrNames that are arrays (empty []), but do process the inflated array items ([0], [1], etc.)
-	if (attrNameType !== attrNameTypeEnum.ARRAY) {
-		var errorsForAttribute = "";
-		
-		var attrValidatorName = attrName.replace(/\[\d+\]/g, "[]");
-		var validateAttribute = this._attributeValidators[attrValidatorName];
-		if (validateAttribute)  {
-		  errorsForAttribute = validateAttribute(this, valueToSet);
-		}
-		if (errorsForAttribute) {
-		  errorHasOccured = true;
-		  errors[attrName] = errorsForAttribute;
-		}
-	}
-	
-  }
+			for (var j = 0; j < attrNameFragments.length; j++) {
+				var element = attrNameFragments[j];
+				var attrNameTypeEnum = {
+					NORMAL : 0,
+					ARRAY : 1,
+					ARRAY_ITEM : 2
+				}
+				var attrNameType = attrNameTypeEnum.NORMAL;
+				var arrayIndex = -1;
+				
+				// Determine attribute name fragment type: (normal, uninflated array [], or inflated array item [n])
+				element = element.replace(/\[(\d*)\]/, function(match, p1) {
+					if (match === "[]") {
+						attrNameType = attrNameTypeEnum.ARRAY;
+					} else {
+						attrNameType = attrNameTypeEnum.ARRAY_ITEM;
+						arrayIndex = p1;
+					}
+					return "";
+				});
+				
+				// Advance the placeholder in the JSON tree to reflect the current attribute name fragment
+				if (j == 0) {
+					if (attrNameType === attrNameTypeEnum.ARRAY_ITEM) {
+						valueToSet = attributes[element][arrayIndex];
+					} else valueToSet = attributes[element];
+				} else {
+					if (attrNameType === attrNameTypeEnum.ARRAY_ITEM) {
+						valueToSet = valueToSet[element][arrayIndex];
+					} else valueToSet = valueToSet[element];
+				}
+					
+				// If this is an uninflated array, inflate it by appending array item entries to the end of attrNames
+				if (attrNameType === attrNameTypeEnum.ARRAY) {
+				  for (var k = 0; k < valueToSet.length; k++) {
+					// Copy attrName into var, find the position of the first [] in the attrName, replace with [j], and push to attrNames
+					var nameToPush = attrName.replace("[]", "[" + k + "]");
+					attrNames.push(nameToPush);
+				  }
+				  break;
+				} 
+			}
 
-  return errorHasOccured ? errors : false;
+			// Skip the attrNames that are arrays (empty []), but do process the inflated array items ([0], [1], etc.)
+			if (attrNameType !== attrNameTypeEnum.ARRAY) {
+				var errorsForAttribute = "";
+				
+				var attrValidatorName = attrName.replace(/\[\d+\]/g, "[]");
+				var validateAttribute = this._attributeValidators[attrValidatorName];
+				if (validateAttribute)  {
+				  errorsForAttribute = validateAttribute(this, valueToSet);
+				}
+				if (errorsForAttribute) {
+				  errorHasOccured = true;
+				  errors[attrName] = errorsForAttribute;
+				}
+			}
+			
+		// if changes have been passed in we can skip the blanket inflation of all arrays and just
+	    // and just validate the changed key and value.
+		} else if (uninflatedChanges[attrName]) {
+
+			  for(var c in chgs){
+				  
+				  var uninflatedC = c.replace(/\[\d+\]/g, "[]");
+				  if(uninflatedC === attrName){
+					  var errorsForAttribute = "";
+					  var valueToSet = chgs[c];
+					  var validateAttribute = this._attributeValidators[attrName];
+					  if (validateAttribute)  {
+						  errorsForAttribute = validateAttribute(this, valueToSet);
+					  }
+					  if (errorsForAttribute) {
+						  errorHasOccured = true;
+						  errors[c] = errorsForAttribute;
+					  }
+				  }
+
+			  }
+
+		  }
+
+		
+	  }   
+	return errorHasOccured ? errors : false;
 }
 
 function createMinValidator(attributeName, minimumValue) {
@@ -294,9 +329,19 @@ function createValidators(modelValidations) {
 }
 
 var oldPerformValidation = Backbone.Model.prototype._performValidation;
-function newPerformValidation(attrs, options) {
+function performNestedValidation(attrs, options, chgs) {
+
   if (options.silent || !this.validate) return true;
-  var errors = this.validate(attrs);
+  
+  var errors = null;
+  
+  // if no changes have been made, there's no reason to validate
+  if(chgs !== undefined && _.isEmpty(chgs)){
+	  errors = this.validate(attrs);
+  }else if(chgs){
+	  errors = this.validate(attrs,chgs);
+  }
+  
   if (errors) {
     if (options.error) {
       options.error(this, errors, options);
@@ -325,7 +370,7 @@ Backbone.Validations.Model = Backbone.Model.extend({
       if (!this.constructor.prototype._attributeValidators) {
         this.constructor.prototype._attributeValidators = createValidators(this.validate);
         this.constructor.prototype.validate = newValidate;
-		this.constructor.prototype._validate = newPerformValidation;
+		this.constructor.prototype._validate = performNestedValidation;
       }
     }
 

--- a/backbone.validations.js
+++ b/backbone.validations.js
@@ -252,6 +252,9 @@ function newPerformValidation(attrs, options) {
     }
     return false;
   }
+  if (attrs) {
+	  this.trigger('validated', this, attrs, options);
+  }
   return true;
 }
 

--- a/backbone.validations.js
+++ b/backbone.validations.js
@@ -44,8 +44,7 @@ var validators = {
   },
 
   "email" : function(type, attributeName, model, valueToSet) {
-    var emailRegex = new RegExp("[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?");
-
+    var emailRegex = new RegExp("[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?");
     if (_.isString(valueToSet) && !valueToSet.match(emailRegex)) {
       return "email";
     }

--- a/test.js
+++ b/test.js
@@ -80,30 +80,25 @@ test("set triggers an error event named after the attribute, on the model", func
 test("set triggers a validated event on the model", function() {
   var TestModel = Backbone.Model.extend({
     validate : {
-      name : {
-        required : true
+      firstName : {
+        pattern   : /^[a-zA-Z]+$/
       },
-	  email : {
-        type: "email"
+	  lastName : {
+        pattern   : /^[a-zA-Z]+$/
 	  }
     }
   });
 
-  var test = new TestModel();
-  var errorCallbackCalled = false;
-
-  test.bind('error', function(model, error) {
-    ok(false);
+  var test = new TestModel({
+    firstName : "John",
+	lastName : "Doe"
   });
   
   test.bind('validated', function(model, attrs) {
-	deepEqual(attrs, {name:"test", email:"test@example.com"});
-	errorCallbackCalled = true;
+	deepEqual(attrs, {firstName: "Jim"});
   });
 
-  test.set({name:"test", email:"test@example.com"});
-
-  ok(errorCallbackCalled);
+  test.set({firstName:"Jim"});
 });
 
 test("providing a direct override prevents normal and named errors from being triggered", function() {

--- a/test.js
+++ b/test.js
@@ -77,6 +77,34 @@ test("set triggers an error event named after the attribute, on the model", func
   ok(errorCallbackCalled);
 });
 
+test("set triggers a validated event on the model", function() {
+  var TestModel = Backbone.Model.extend({
+    validate : {
+      name : {
+        required : true
+      },
+	  email : {
+        type: "email"
+	  }
+    }
+  });
+
+  var test = new TestModel();
+  var errorCallbackCalled = false;
+
+  test.bind('error', function(model, error) {
+    ok(false);
+  });
+  
+  test.bind('validated', function(model, attrs) {
+	deepEqual(attrs, {name:"test", email:"test@example.com"});
+	errorCallbackCalled = true;
+  });
+
+  test.set({name:"test", email:"test@example.com"});
+
+  ok(errorCallbackCalled);
+});
 
 test("providing a direct override prevents normal and named errors from being triggered", function() {
   var nameOfAttribute = "name";
@@ -654,6 +682,7 @@ test("save options success", function() {
     }
   });
 });
+
 
 
 });

--- a/testIntegrationWithBackboneNested.htm
+++ b/testIntegrationWithBackboneNested.htm
@@ -189,7 +189,7 @@ $(document).ready(function(){
 		// Create error binding for validation error
 		this.nvm.bind('error', function(model, errors) {
 			errorCallbackCalled = true;
-			deepEqual(errors, {"firstLevelArray[].firstLevelArrObjAttrB":["minlength"]});
+			deepEqual(errors, {"firstLevelArray[1].firstLevelArrObjAttrB":["minlength"]});
 		});
 		
 		// Change a nested field
@@ -208,7 +208,7 @@ $(document).ready(function(){
 		
 		this.nvm.bind('error', function(model, errors) {
 			errorCallbackCalled = true;
-			deepEqual(errors, {"firstLevelChild.secondLevelArray[].secondLevelArrObjAttrA":["pattern"]});
+			deepEqual(errors, {"firstLevelChild.secondLevelArray[2].secondLevelArrObjAttrA":["pattern"]});
 		});
 		
 		this.nvm.set({"firstLevelChild.secondLevelArray[2].secondLevelArrObjAttrA" : "$$$"});
@@ -233,7 +233,7 @@ $(document).ready(function(){
 		
 		this.nvm.bind('error', function(model, errors) {
 			errorCallbackCalled = true;
-			deepEqual(errors, {"firstLevelArray[].arrOfArrs[].arrOfArrsObjAttrB":["pattern"]});
+			deepEqual(errors, {"firstLevelArray[1].arrOfArrs[1].arrOfArrsObjAttrB":["pattern"]});
 		});
 		
 		this.nvm.set({"firstLevelArray[1].arrOfArrs[1].arrOfArrsObjAttrB" : "$$$"});
@@ -256,9 +256,9 @@ $(document).ready(function(){
 		
 		var errorCallbackCalled = false;
 		
-		this.nvm.bind('error:firstLevelChild.secondLevelArray[].secondLevelArrObjAttrA', function(model, errors) {
+		this.nvm.bind('error:firstLevelChild.secondLevelArray[2].secondLevelArrObjAttrA', function(model, errors) {
 			errorCallbackCalled = true;
-			deepEqual(errors, {"firstLevelChild.secondLevelArray[].secondLevelArrObjAttrA":["pattern"]});
+			deepEqual(errors, {"firstLevelChild.secondLevelArray[2].secondLevelArrObjAttrA":["pattern"]});
 		});
 		
 		this.nvm.set({"firstLevelChild.secondLevelArray[2].secondLevelArrObjAttrA" : "$$$" });

--- a/testIntegrationWithBackboneNested.htm
+++ b/testIntegrationWithBackboneNested.htm
@@ -1,0 +1,316 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html>
+    <head>
+        <meta name="generator" content="HTML Tidy for Windows (vers 14 February 2006), see www.w3.org">
+        <script src="http://code.jquery.com/jquery-latest.js" type="text/javascript"></script>
+        <link rel="stylesheet" href="http://code.jquery.com/qunit/git/qunit.css" type="text/css" media="screen">
+        <script type="text/javascript" src="http://code.jquery.com/qunit/git/qunit.js"></script>
+		<script type="text/javascript" src="http://documentcloud.github.com/underscore/underscore.js"></script>
+		<script type="text/javascript" src="http://documentcloud.github.com/backbone/backbone.js"></script>
+		<script type="text/javascript" src="backbone.validations.js"></script>
+		<script type="text/javascript" src="https://raw.github.com/afeld/backbone-nested/master/backbone-nested.js"></script>
+ 
+ <script type="text/javascript">
+$(document).ready(function(){
+
+	module("Validation", {
+			
+		setup: function() {
+			
+			// Top level parent model with nested stuff
+			this.NestedValidatingModel = Backbone.NestedModel.extend({
+				validate : {
+					parentAttrA : {
+						minlength : 16
+					},
+					parentAttrB : {
+						minlength : 16
+					},
+					"firstLevelChild.firstLevelChildAttrA" : {
+						minlength : 25
+					},
+					"firstLevelArray[].firstLevelArrObjAttrA" : {
+						minlength : 27
+					},
+					"firstLevelArray[].firstLevelArrObjAttrB" : {
+						minlength : 27
+					},
+					"firstLevelChild.secondLevelArray[].secondLevelArrObjAttrA" : {
+						pattern   : /^[a-zA-Z0-9]+$/
+					},
+					"firstLevelArray[].arrOfArrs[].arrOfArrsObjAttrB" : {
+						pattern   : /^[a-zA-Z0-9]+$/
+					}
+				}
+			});
+			this.nvm = new this.NestedValidatingModel({
+				parentAttrA : "parentAttrAValue",
+				parentAttrB : "parentAttrBValue",
+				firstLevelChild : {
+					firstLevelChildAttrA : "firstLevelChildAttrAValue",
+					firstLevelChildAttrB : "firstLevelChildAttrBValue",
+					secondLevelArray : [
+						{
+							secondLevelArrObjAttrA : "secondLevelArrObj0AttrAValue",
+							secondLevelArrObjAttrB : "secondLevelArrObj0AttrBValue"
+						},
+						{
+							secondLevelArrObjAttrA : "secondLevelArrObj1AttrAValue",
+							secondLevelArrObjAttrB : "secondLevelArrObj1AttrBValue"
+						},
+						{	
+							secondLevelArrObjAttrA : "secondLevelArrObj2AttrAValue",
+							secondLevelArrObjAttrB : "secondLevelArrObj2AttrBValue"
+						}
+					]
+				},
+				firstLevelArray : [
+					{
+						firstLevelArrObjAttrA : "firstLevelArrObj0AttrAValue",
+						firstLevelArrObjAttrB : "firstLevelArrObj0AttrBValue",
+						arrOfArrs : [
+							{
+								arrOfArrsObjAttrA : "arrOfArr0ObjAttrAVal",
+								arrOfArrsObjAttrB : "arrOfArr0ObjAttrBVal"
+							},
+							{
+								arrOfArrsObjAttrA : "arrOfArr0ObjAttrAVal",
+								arrOfArrsObjAttrB : "arrOfArr0ObjAttrBVal"
+							},
+							{
+								arrOfArrsObjAttrA : "arrOfArr0ObjAttrAVal",
+								arrOfArrsObjAttrB : "arrOfArr0ObjAttrBVal"
+							}
+						]
+					},
+					{
+						firstLevelArrObjAttrA : "firstLevelArrObj1AttrAValue",
+						firstLevelArrObjAttrB : "firstLevelArrObj1AttrBValue",
+						arrOfArrs : [
+							{
+								arrOfArrsObjAttrA : "arrOfArr1ObjAttrAVal",
+								arrOfArrsObjAttrB : "arrOfArr1ObjAttrBVal"
+							},
+							{
+								arrOfArrsObjAttrA : "arrOfArr1ObjAttrAVal",
+								arrOfArrsObjAttrB : "arrOfArr1ObjAttrBVal"
+							},
+							{
+								arrOfArrsObjAttrA : "arrOfArr1ObjAttrAVal",
+								arrOfArrsObjAttrB : "arrOfArr1ObjAttrBVal"
+							}
+						]
+					},
+					{
+						firstLevelArrObjAttrA : "firstLevelArrObj2AttrAValue",
+						firstLevelArrObjAttrB : "firstLevelArrObj2AttrBValue",
+						arrOfArrs : [
+							{
+								arrOfArrsObjAttrA : "arrOfArr2ObjAttrAVal",
+								arrOfArrsObjAttrB : "arrOfArr2ObjAttrBVal"
+							},
+							{
+								arrOfArrsObjAttrA : "arrOfArr2ObjAttrAVal",
+								arrOfArrsObjAttrB : "arrOfArr2ObjAttrBVal"
+							},
+							{
+								arrOfArrsObjAttrA : "arrOfArr2ObjAttrAVal",
+								arrOfArrsObjAttrB : "arrOfArr2ObjAttrBVal"
+							}
+						]
+					}
+				]
+			});
+			
+			// Top level parent view
+			this.ParentBBView = Backbone.View.extend({
+				el : $("#qunit-fixture"),
+				template : _.template($('#parentTemplate').html()),
+				initialize : function() {
+					this.$el.empty();
+					this.$el.append(this.template(this.model.toJSON()));
+				},
+				model : this.nvm
+			});
+			this.parentBBView = new this.ParentBBView();
+			
+		},
+		
+		teardown: function() {
+		
+		}
+	
+	});
+	
+	test("simple validation", function() {
+		var errorCallbackCalled = false;
+		
+		// Create error binding for validation error
+		this.nvm.bind('error', function(model, errors) {
+			errorCallbackCalled = true;
+			deepEqual(errors, {"parentAttrA":["minlength"]});
+		});
+		
+		// Change a top level field
+		this.nvm.set({parentAttrA:"tooShortPAttrA"});
+		
+		ok(errorCallbackCalled);
+		
+		// Model should not have been updated
+		notEqual( this.nvm.get("parentAttrA"), "tooShortPAttrA", "Parent model parentAttrA not updated due to validation" );
+		
+	});
+
+	test("nested validation", function() {
+		
+		var errorCallbackCalled = false;
+		
+		// Create error binding for validation error
+		this.nvm.bind('error', function(model, errors) {
+			errorCallbackCalled = true;
+			deepEqual(errors, {"firstLevelChild.firstLevelChildAttrA":["minlength"]});
+		});
+		
+		// Change a nested field
+		this.nvm.set({"firstLevelChild.firstLevelChildAttrA": "tooShortFLCAttrAVal"});
+		
+		ok(errorCallbackCalled);
+		
+		// Model should not have been updated
+		notEqual( this.nvm.get("firstLevelChild.firstLevelChildAttrA"), "tooShortFLCAttrAVal", "Child attribute not updated due to validation" );
+		
+	});
+	
+	test("nested array validation", function() {
+		
+		var errorCallbackCalled = false;
+		
+		// Create error binding for validation error
+		this.nvm.bind('error', function(model, errors) {
+			errorCallbackCalled = true;
+			deepEqual(errors, {"firstLevelArray[].firstLevelArrObjAttrB":["minlength"]});
+		});
+		
+		// Change a nested field
+		this.nvm.set({"firstLevelArray[1].firstLevelArrObjAttrB" : "tooShortFLArrO1AttrBValue"});
+		
+		ok(errorCallbackCalled);
+		
+		// Model should not have been updated
+		notEqual( this.nvm.get("firstLevelArray[1].firstLevelArrObjAttrB"), "tooShortFLArrO1AttrBValue", "Nested array attribute not updated due to validation" );
+		
+	});
+	
+	test("second-level nested array validation", function() {
+		
+		var errorCallbackCalled = false;
+		
+		this.nvm.bind('error', function(model, errors) {
+			errorCallbackCalled = true;
+			deepEqual(errors, {"firstLevelChild.secondLevelArray[].secondLevelArrObjAttrA":["pattern"]});
+		});
+		
+		this.nvm.set({"firstLevelChild.secondLevelArray[2].secondLevelArrObjAttrA" : "$$$"});
+		
+		ok(errorCallbackCalled);
+		
+		notEqual( this.nvm.get("firstLevelChild.secondLevelArray[2].secondLevelArrObjAttrA"), "$$$", "Second-level nested array attribute not updated due to validation" );
+		
+		errorCallbackCalled = false;
+		
+		this.nvm.set({"firstLevelChild.secondLevelArray[2].secondLevelArrObjAttrA" : "valid"});
+		
+		ok(!errorCallbackCalled);
+		
+		equal( this.nvm.get("firstLevelChild.secondLevelArray[2].secondLevelArrObjAttrA"), "valid", "Second-level nested array attribute updated due to validation passing" );
+		
+	});
+	
+	test("array of array validation", function() {
+		
+		var errorCallbackCalled = false;
+		
+		this.nvm.bind('error', function(model, errors) {
+			errorCallbackCalled = true;
+			deepEqual(errors, {"firstLevelArray[].arrOfArrs[].arrOfArrsObjAttrB":["pattern"]});
+		});
+		
+		this.nvm.set({"firstLevelArray[1].arrOfArrs[1].arrOfArrsObjAttrB" : "$$$"});
+		
+		ok(errorCallbackCalled);
+		
+		notEqual( this.nvm.get("firstLevelArray[1].arrOfArrs[1].arrOfArrsObjAttrB"), "$$$", "Array of array attribute not updated due to validation" );
+		
+		errorCallbackCalled = false;
+		
+		this.nvm.set({"firstLevelArray[1].arrOfArrs[1].arrOfArrsObjAttrB" : "valid"});
+		
+		ok(!errorCallbackCalled);
+		
+		equal( this.nvm.get("firstLevelArray[1].arrOfArrs[1].arrOfArrsObjAttrB"), "valid", "Array of array attribute updated due to validation passing" );
+		
+	});
+	
+	test("triggers error event named after nested attribute", function() {
+		
+		var errorCallbackCalled = false;
+		
+		this.nvm.bind('error:firstLevelChild.secondLevelArray[].secondLevelArrObjAttrA', function(model, errors) {
+			errorCallbackCalled = true;
+			deepEqual(errors, {"firstLevelChild.secondLevelArray[].secondLevelArrObjAttrA":["pattern"]});
+		});
+		
+		this.nvm.set({"firstLevelChild.secondLevelArray[2].secondLevelArrObjAttrA" : "$$$" });
+		
+		ok(errorCallbackCalled);
+	});
+});
+ </script>
+ 
+    <title></title>
+    </head>
+    <body>
+        <h1 id="qunit-header">
+            Backbone.Validations Integration Test with Backbone-Nested
+        </h1>
+        <h2 id="qunit-banner"></h2>
+        <div id="qunit-testrunner-toolbar"></div>
+        <h2 id="qunit-userAgent"></h2>
+        <ol id="qunit-tests"></ol>
+        
+		
+		<!-- THE FIXTURE -->
+		<div id="qunit-fixture">
+		   
+		   <!-- PARENT TEMPLATE -->
+		   <script type="text/template" id="parentTemplate">
+			   <input name="parentAttrA" type="text" />
+			   <span id="parentAttrAError" class="error"></span>
+			   
+			   <input name="parentAttrB" type="text" />
+			   <span id="parentAttrBError" class="error"></span>
+			   
+				<div>
+					<input name="firstLevelChild.firstLevelChildAttrA" type="text" />
+				</div>
+			   
+				<div>
+					<input name="firstLevelArray[1].firstLevelArrObjAttrB" type="text" />
+				</div>
+			   
+				<div>
+					<input name="firstLevelChild.secondLevelArray[2].secondLevelArrObjAttrA" type="text" />
+				</div>
+				
+				<div>
+					<input name="firstLevelArray[1].arrOfArrs[1].arrOfArrsObjAttrB" type="text" />
+				</div>
+		   </script>
+		   
+		   
+		</div>
+		
+		
+    </body>
+</html>


### PR DESCRIPTION
There are certain situations where the developer may want to see a "validated" event, rather than just relying on the change event triggered by model.set. For example:
1. You have a form field tied to validation. It currently has a valid value.
2. The user changes the field to an invalid value, triggering an error from validation. The model has not been updated, however, because validation fails.
3. An error message is displayed to the user.
4. The user changes the field back to a valid value, and you want to listen for an event to remove the error message. You cannot use the change event, because change will not be fired (the new value supplied by the user is the same as the old one that is still on the model).
