### PR TITLE
Prevent invalid 'required' field being saved to model if its already set...

### DIFF
--- a/backbone.validations.js
+++ b/backbone.validations.js
@@ -29,10 +29,7 @@ var validators = {
   },
 
   "required" : function(attributeName, model, valueToSet) {
-    var currentValue = model.get(attributeName);
-    var isNotAlreadySet = _.isUndefined(currentValue);
-    var isNotBeingSet = _.isUndefined(valueToSet);
-    if (_.isNull(valueToSet) || valueToSet === "" || (isNotBeingSet && isNotAlreadySet)) {
+    if (_.isNull(valueToSet) || _.isUndefined(valueToSet) || valueToSet === "") {
       return "required";
     } else {
       return false;

--- a/test.js
+++ b/test.js
@@ -234,6 +234,7 @@ test("won't allow a value to be set to null, or blank", function() {
   var t = new TestModel;
 
   equal(t.set({name: null}), false);
+  equal(t.set({name: undefined}), false);
   equal(t.set({name: ""}), false);
 });
 
@@ -567,7 +568,7 @@ test("proper shaped responses", function() {
   equal(vm.set({name: "neal", age: 201}), false);
 });
 
-test("maxlength", function() {
+test("minlength", function() {
   var ValidatingModel = Backbone.Model.extend({
     validate : {
       name : {


### PR DESCRIPTION
Current implementation enables invalid required field value being saved to model if its already set value is not undefined.

1    var currentValue = model.get(attributeName);
2    var isNotAlreadySet = _ .isUndefined(currentValue);
3    var isNotBeingSet = _ .isUndefined(valueToSet);
4    if (_.isNull(valueToSet) || valueToSet === "" || (isNotBeingSet && isNotAlreadySet)) {

This means, attempt to save 'undefined' value will be successful despite the fact error will be eventually generated and shown.

This very small fix will help to overcome the problem and make validation for required field work as expected.
