### PR TITLE
Skip validations when required set to false and value is null or undefined

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,12 @@ var ValidatingModel = Backbone.Model.extend({
       minlength : 3,
       maxlength : 100
     },
+    nickname : {
+      required  : false,
+      pattern   : /^[a-zA-Z]+$/,
+      minlength : 3,
+      maxlength : 100
+    },
     age : {
       type: "number",
       min: 0,

--- a/backbone.validations.js
+++ b/backbone.validations.js
@@ -247,8 +247,6 @@ function createValidators(modelValidations) {
   var attributeValidations,
       attributeValidators = {};
 
-  var optional = modelValidations['required'] === 'false';
-
   for (var attrName in modelValidations) {
     attributeValidations = modelValidations[attrName];
     attributeValidators[attrName] = createAttributeValidator(attrName, attributeValidations);

--- a/backbone.validations.js
+++ b/backbone.validations.js
@@ -29,7 +29,7 @@ var validators = {
   },
 
   "required" : function(isRequired, attributeName, model, valueToSet) {
-    if( isRequired === false ) return false;
+    if (isRequired === false) return false;
     if ( _.isNull(valueToSet) || _.isUndefined(valueToSet) || valueToSet === "") {
       return "required";
     } else {
@@ -60,7 +60,7 @@ var validators = {
   "number" : function(type, attributeName, model, valueToSet) {
     return isNaN(valueToSet) ? 'number' : undefined;
   },
-  
+
   "digits": function (type, attributeName, model, valueToSet) {
     var isBeingSet = !_.isUndefined(valueToSet);
     return (!/^\d+$/.test(valueToSet) && isBeingSet) ? 'digits' : undefined;
@@ -200,14 +200,15 @@ function createAttributeValidator(attributeName, attributeDescription) {
 
   for (type in attributeDescription) {
     desc = attributeDescription[type];
-    validatorsForAttribute.push( function(){
-      if( type === 'required' || !optional ){
+
+    var validator = (function(){
+      if (type === 'required' || !optional) {
         return createValidator(attributeName, type, desc);
       } else {
         return (function(){
-          var validator = createValidator(attributeName, type, desc)
+          var validator = createValidator(attributeName, type, desc);
           return function(model, valueToSet){
-            if( _.isUndefined(valueToSet) || _.isNull(valueToSet) ){
+            if ( _.isUndefined(valueToSet) || _.isNull(valueToSet)) {
               return false;
             } else {
               return validator(model, valueToSet);
@@ -216,6 +217,8 @@ function createAttributeValidator(attributeName, attributeDescription) {
         })();
       }
     }());
+
+    validatorsForAttribute.push( validator );
   }
 
   return function(model, valueToSet, hasOverridenError, options) {

--- a/test.js
+++ b/test.js
@@ -238,6 +238,40 @@ test("won't allow a value to be set to null, or blank", function() {
   equal(t.set({name: ""}), false);
 });
 
+test("when explicity set to false other validators are skipped", function() {
+  var TestModel = Backbone.Model.extend({
+    validate : {
+      size : {
+        type: 'number',
+        min: 0,
+        max: 5,
+        required : false,
+      }
+    }
+  });
+
+  var t = new TestModel;
+  equal(t.set({size: 'a'}), false);
+  equal(t.set({size: 6}), false);
+  equal(t.set({other: null}), t);
+  equal(t.set({size: 2}), t);
+});
+
+test("when not explicity set to false other validators are not skipped", function() {
+  var TestModel = Backbone.Model.extend({
+    validate : {
+      size : {
+        type: 'number',
+        min: 0,
+        max: 10
+      }
+    }
+  });
+
+  var t = new TestModel;
+  equal(t.set({other: null}), false);
+});
+
 module("custom attribute validator");
 test("it calls the custom validator", function() {
   var customValidatorCalled = false;


### PR DESCRIPTION
When required is set to false the other validators on the attrubute are only run if the new attribute value is not null or undefined.

``` js
var Foo = Backbone.Model.extend({
  validate: {
    age: {
      type: 'number'
    }
  }
});

var foo = new Foo();
foo.set({blah: 'xyzzy'}); // => false
foo.isValid(); // => false


var Bar = Backbone.Model.extend({
  validate: {
    age: {
      type: 'number',
      required: false
    }
  }
});

var bar = new Bar();
bar.set({blah: 'xyzzy'}); // => bar
bar.isValid(); // => true
bar.set({age: 'old'}); // => false
bar.set({age: 1});
bar.isValid(); // => true
```
