### PR TITLE
Support for defining validate as a function which returns an object

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -37,6 +37,18 @@ var ValidatingModel = Backbone.Model.extend({
 });
 ```
 
+Alternatively, you may also define a function which returns an object literal of the same type:
+
+```javascript
+var ValidatingModel = Backbone.Model.extend({
+  validate : function () {
+    return {
+      // validate object
+    };
+  }
+});
+```
+
 ## Built-In Validations
 - in
   - Takes an array of values, compares with ==

--- a/backbone.validations.js
+++ b/backbone.validations.js
@@ -279,9 +279,10 @@ var oldModel = Backbone.Model;
 Backbone.Validations.Model = Backbone.Model.extend({
   constructor : function() {
     // if they pass an object, construct the new validations
-    if (typeof this.validate === "object" && this.validate !== null) {
+    var validate = _.result(this, 'validate');
+    if (typeof validate === "object" && validate !== null) {
       if (!this.constructor.prototype._attributeValidators) {
-        this.constructor.prototype._attributeValidators = createValidators(this.validate);
+        this.constructor.prototype._attributeValidators = createValidators(validate);
         this.constructor.prototype.validate = newValidate;
         this.constructor.prototype._validate = newPerformValidation;
       }

--- a/test.js
+++ b/test.js
@@ -211,6 +211,25 @@ test("doesn't set other values, when there is no current value, and no value is 
   equal(t.get('woo'), undefined);
 });
 
+module("validate as a function");
+
+test("defining validate as a function which returns an object works", function() {
+  var TestModel = Backbone.Model.extend({
+    validate : function () {
+      return {
+        name : {
+          required : true
+        }
+      };
+    }
+  });
+
+  var t = new TestModel;
+
+  equal(t.set({woo: "hoo"}, {validate: true}), false);
+  equal(t.get('woo'), undefined);
+});
+
 
 test("won't allow a value to be set to null, or blank", function() {
   var TestModel = Backbone.Model.extend({


### PR DESCRIPTION
This tiny pull request leverages `_.result(this, validate)` to add support for `validate` being a function which returns an object rather than just an object.  This is how backbone core does it as well.  For example, `defaults` can either be an object or a function which returns an object.

Tests and documentation are updated, but if there are any other changes you would like as a part of this, please let me know and I'll be happy to make them!
